### PR TITLE
libipset testing/linkage, dynamic module support

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -16,3 +16,13 @@ In comparison to standard nginx access module this allows for dynamic list updat
     sudo ipset -A myblacklist 127.0.0.1
 * Start nginx
 * Profit!
+
+== Installation as dynamic module
+
+Alternatively, you can compile a dynamic module for nginx with:
+    ./configure --add-dynamic-module=/path/to/ngx_http_ipset_access --with-compat
+
+After compilation, locate `objs/ngx_http_ipset_access.so`.
+
+To load the compiled module into nginx, add the following at the top of nginx.conf:
+    load_module /path/to/ngx_http_ipset_access.so;

--- a/README.rdoc
+++ b/README.rdoc
@@ -7,9 +7,9 @@ In comparison to standard nginx access module this allows for dynamic list updat
 
 * Get youself a linux server with root access
 * Get nginx source code, unpack etc.
-* Install libssl-dev, pcre and other nginx requirements
+* Install libipset, libssl-dev, pcre and other nginx requirements
 * Configure nginx with this module:
-    ./configure --add-module=/path/to/ngx_http_ipset_access --with-ld-opt=-lipset
+    ./configure --add-module=/path/to/ngx_http_ipset_access
 * Compile, install
 * Create yout ipset and add some 'offending' ips to it:
     sudo ipset -N myblacklist iphash

--- a/config
+++ b/config
@@ -1,4 +1,31 @@
-ngx_addon_name=ngx_http_ipset_access
-HTTP_MODULES="$HTTP_MODULES ngx_http_ipset_access"
+ngx_feature="libipset library"
+ngx_feature_name=
+ngx_feature_run=no
+ngx_feature_incs="#include <libipset/linux_ip_set.h>"
+ngx_feature_libs=-lipset
+ngx_feature_test="IPSET_CMD_TEST"
+. auto/feature
 
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_ipset_access.c"
+ngx_addon_name=ngx_http_ipset_access
+
+if [ $ngx_found = yes ]; then
+
+    if test -n "$ngx_module_link"; then
+        ngx_module_type=HTTP
+        ngx_module_name=ngx_http_ipset_access
+        ngx_module_srcs="$ngx_addon_dir/ngx_http_ipset_access.c"
+        ngx_module_libs="$ngx_feature_libs"
+
+        . auto/module
+    else
+        HTTP_MODULES="$HTTP_MODULES ngx_http_ipset_access"
+        NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_ipset_access.c"
+        CORE_LIBS="$CORE_LIBS $ngx_feature_libs"
+    fi
+
+else
+	cat << END
+$0: error: the ngx_http_ipset_access module requires the ipset library.
+END
+	exit 1
+fi


### PR DESCRIPTION
* allows compiling the module as dynamic
* links in libipset with config, so there's no need to do that explicitly